### PR TITLE
Make it work with a custom instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ Or via CDN:
 ---
 
 ### Usage
-Invoke (only one time) the function: `loadProgressBar(config)`, where the config argument is the configuration object for the [nprogress](https://www.npmjs.com/package/nprogress) and is not required. Its properties can be seen [here](https://www.npmjs.com/package/nprogress#configuration). 
+Invoke (only one time) the function: `loadProgressBar(config, instance)`.
+
+### Nprogress Config
+the `config` argument is the configuration object for the [nprogress](https://www.npmjs.com/package/nprogress). Its properties can be seen [here](https://www.npmjs.com/package/nprogress#configuration).
+
+### Custom Axios Instance
+You can pass a [Custom Axios Instance](https://github.com/axios/axios#custom-instance-defaults) as a second argument if needed, the argument is not required. If you don't set the `instance` argument the default axios instance will be used.
+
+
+
 
 __Also, you need to import the CSS file ([nprogress.css](https://cdn.rawgit.com/rikmms/progress-bar-4-axios/0a3acf92/dist/nprogress.css)) that contains the customization of the progress bar.__
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -108,12 +108,15 @@ var calculatePercentage = function calculatePercentage(loaded, total) {
   return Math.floor(loaded * 1.0) / total;
 };
 
-function loadProgressBar(config) {
+function loadProgressBar() {
+  var instance = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _axios2.default;
+  var config = arguments[1];
+
 
   var requestsCounter = 0;
 
   var setupStartProgress = function setupStartProgress() {
-    _axios2.default.interceptors.request.use(function (config) {
+    instance.interceptors.request.use(function (config) {
       requestsCounter++;
       _nprogress2.default.start();
       return config;
@@ -124,8 +127,8 @@ function loadProgressBar(config) {
     var update = function update(e) {
       return _nprogress2.default.inc(calculatePercentage(e.loaded, e.total));
     };
-    _axios2.default.defaults.onDownloadProgress = update;
-    _axios2.default.defaults.onUploadProgress = update;
+    instance.defaults.onDownloadProgress = update;
+    instance.defaults.onUploadProgress = update;
   };
 
   var setupStopProgress = function setupStopProgress() {
@@ -139,7 +142,7 @@ function loadProgressBar(config) {
       return Promise.reject(error);
     };
 
-    _axios2.default.interceptors.response.use(responseFunc, errorFunc);
+    instance.interceptors.response.use(responseFunc, errorFunc);
   };
 
   _nprogress2.default.configure(config);

--- a/dist/index.js
+++ b/dist/index.js
@@ -108,9 +108,8 @@ var calculatePercentage = function calculatePercentage(loaded, total) {
   return Math.floor(loaded * 1.0) / total;
 };
 
-function loadProgressBar() {
-  var instance = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _axios2.default;
-  var config = arguments[1];
+function loadProgressBar(config) {
+  var instance = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _axios2.default;
 
 
   var requestsCounter = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-progress-bar",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -251,6 +251,15 @@
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
         "postcss-value-parser": "3.3.0"
+      }
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
       }
     },
     "babel-code-frame": {
@@ -2355,6 +2364,24 @@
         "readable-stream": "2.3.3"
       }
     },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3721,8 +3748,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4290,8 +4316,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,12 @@ import axios from 'axios'
 const calculatePercentage = (loaded, total) => (Math.floor(loaded * 1.0) / total)
 
 
-export function loadProgressBar(config) {
+export function loadProgressBar(instance = axios, config) {
   
   let requestsCounter = 0
   
   const setupStartProgress = () => {
-    axios.interceptors.request.use(config => {
+    instance.interceptors.request.use(config => {
       requestsCounter++
       NProgress.start()
       return config
@@ -20,8 +20,8 @@ export function loadProgressBar(config) {
   
   const setupUpdateProgress = () => {
     const update = e => NProgress.inc(calculatePercentage(e.loaded, e.total))
-    axios.defaults.onDownloadProgress = update
-    axios.defaults.onUploadProgress = update
+    instance.defaults.onDownloadProgress = update
+    instance.defaults.onUploadProgress = update
   }
   
   const setupStopProgress = () => {
@@ -37,7 +37,7 @@ export function loadProgressBar(config) {
       return Promise.reject(error)
     }
 
-    axios.interceptors.response.use(responseFunc, errorFunc)
+    instance.interceptors.response.use(responseFunc, errorFunc)
   }
 
   NProgress.configure(config)

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import axios from 'axios'
 const calculatePercentage = (loaded, total) => (Math.floor(loaded * 1.0) / total)
 
 
-export function loadProgressBar(instance = axios, config) {
+export function loadProgressBar(config, instance = axios) {
   
   let requestsCounter = 0
   

--- a/test-environment/index.html
+++ b/test-environment/index.html
@@ -24,7 +24,7 @@
       baseURL: 'https://reqres.in/api/',
     });
     loadProgressBar()
-    loadProgressBar(customInstance);
+    loadProgressBar(undefined, customInstance);
 
     function getResource() {
       getRequest('https://reqres.in/api/users?page=1')

--- a/test-environment/index.html
+++ b/test-environment/index.html
@@ -10,6 +10,7 @@
   <body>
     <h3>Use <a href="https://reqres.in/">Reqres</a> for testing...</h3>
     <button onclick="getResource()">Get Resource</button>
+    <button onclick="getResourceWithCustomInstance()">Get Resource using an Axios custom Instance</button>
     <button onclick="resourceNotFound()">Resource Not Found</button>
     <button onclick="createResource()">Create Resource</button>
     <button onclick="unsuccessfulCreateResource()">Unsuccessful Create Resource</button>
@@ -19,11 +20,18 @@
   <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
   <script src="../dist/index.js"></script>
   <script type="text/javascript">
-
+    const customInstance = axios.create({
+      baseURL: 'https://reqres.in/api/',
+    });
     loadProgressBar()
+    loadProgressBar(customInstance);
 
     function getResource() {
       getRequest('https://reqres.in/api/users?page=1')
+    }
+    
+    function getResourceWithCustomInstance() {
+      getRequestWithCustomInstance('users?page=1')
     }
 
     function resourceNotFound() {
@@ -58,6 +66,16 @@
 
     function postRequest(url, form) {
       axios.post(url, form)
+      .then(function (response) {
+        console.log(response)
+      })
+      .catch(function (error) {
+        console.log(error)
+      })
+    }
+
+    function getRequestWithCustomInstance(endpoint) {
+      customInstance.get(endpoint)
       .then(function (response) {
         console.log(response)
       })


### PR DESCRIPTION
Solves #5 

Now an axios custom instance can be pass to the function as a param. I put it as the second param to not affect current applications that are maybe using the nprogress config. 

My suggestion is that the function should receive one single param which would be an object containing the custom instance and the nprogress config.