### PR TITLE
Allow an axios request to bypass the progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ import 'axios-progress-bar/dist/nprogress.css'
 </html>
 ```
 
+### Disable progress bar for specific axios requests
+Sometimes we don't want to show the progress bar for an axios request (like UX which have degradeable typeaheads).  
+To prevent it from popping up for that request, you can pass in `false` for the `progress` parameter in your axios request.
+```js
+axios.get('URL', { progress: false })  
+axios.post('URL', data, { progress: false })
+```
+
 ### Tip
 The CSS file contains the properties from the [nprogress style](https://github.com/rstacruz/nprogress/blob/master/nprogress.css). However, It's possible to override the properties or set new ones with a custom CSS.
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,13 @@ export function loadProgressBar (config, instance = axios) {
 
   const setupStartProgress = () => {
     instance.interceptors.request.use(config => {
-      requestsCounter++
-      NProgress.start()
+      if (config && config.progress === false) {
+        config.onDownloadProgress = null
+        config.onUploadProgress = null
+      } else {
+        requestsCounter++
+        NProgress.start()
+      }
       return config
     })
   }
@@ -24,14 +29,14 @@ export function loadProgressBar (config, instance = axios) {
 
   const setupStopProgress = () => {
     const responseFunc = response => {
-      if ((--requestsCounter) === 0) {
+      if ((!response || !response.config || !(response.config.progress === false)) && (--requestsCounter) === 0) {
         NProgress.done()
       }
       return response
     }
 
     const errorFunc = error => {
-      if ((--requestsCounter) === 0) {
+      if ((!error || !error.config || !(error.config.progress === false)) && (--requestsCounter) === 0) {
         NProgress.done()
       }
       return Promise.reject(error)


### PR DESCRIPTION
I have lots of typeahead requests that fire off while a user is using the app.  They're degradeable, and the constant progress bar popping up was not necessary.  This change allows you to specify specific Axios requests to not influence the progressbar showing/hiding/etc.  